### PR TITLE
Add and easy-to-configure minimal backend, handle objects from backend modules in main class

### DIFF
--- a/abc_tylstore.py
+++ b/abc_tylstore.py
@@ -4,6 +4,7 @@ from CONSTS import C
 
 class TYLPersistant(object):
     __metaclass__ = abc.ABCMeta
+    # TODO: Assignment to this variable from pyterrabacktyl is probably duck-typing in a new variable.
     __lock_state__ = C.LOCK_STATE_UNLOCKED
 
     @abc.abstractmethod
@@ -49,6 +50,7 @@ class TYLPersistant(object):
 
 class TYLNonpersistant(object):
     __metaclass__ = abc.ABCMeta
+    # TODO: Assignment to these variables from pyterrabacktyl is probably duck-typing in a new variable.
     __logged_errors__ = 0
     __recent_error__ = ''
 

--- a/backends/pyshelve_backend.py
+++ b/backends/pyshelve_backend.py
@@ -1,0 +1,81 @@
+import os
+import json
+import shelve
+import logging
+
+from collections import defaultdict
+from abc_tylstore import TYLPersistant
+
+__version__ = '0.1.0'
+
+
+class _lazyShelf(object):
+    def __init__(self, filename):
+        self.filename = filename
+
+    def __setitem__(self, key, value):
+        sf = shelve.open(self.filename)
+        sf[key] = value
+        sf.close()
+
+    def __getitem__(self, key):
+        sf = shelve.open(self.filename)
+        value = sf[key]
+        sf.close()
+        return value
+
+    def __delitem__(self, key):
+        sf = shelve.open(self.filename)
+        del sf[key]
+        sf.close()
+
+    def __contains__(self, key):
+        sf = shelve.open(self.filename)
+        value = key in sf
+        sf.close()
+        return value
+
+
+class PyShelveBackend(TYLPersistant):
+    def __init__(self, environment, constants, parent):
+        self.C = constants
+        self.C.TFSTATE_KEYWORD = 'TFSTATE'
+        self.C.LOCK_STATE_KEYWORD = 'LOCK_ STATE'
+        self.ENV = environment
+        self.parent = parent
+
+        self.tfstate_file_name = os.sep.join([self.C.PYSHELVE_DATA_PATH, self.ENV+self.C.PYSHELVE_DB_FILE_NAME])
+        self.tfstate_shelf = _lazyShelf(self.tfstate_file_name)
+
+        if self.C.TFSTATE_KEYWORD not in self.tfstate_shelf:
+            self.tfstate_shelf[self.C.TFSTATE_KEYWORD] = ''
+
+    def set_locked(self, state_obj, **kwargs):
+        if self.C.LOCK_STATE_KEYWORD in self.tfstate_shelf:
+            logging.warning('Failed to obtain lock for ENV %s, already locked' % self.ENV)
+            return False
+
+        logging.info('Locking ENV %s' % self.ENV)
+        self.tfstate_shelf[self.C.LOCK_STATE_KEYWORD] = state_obj
+        return True
+
+    def set_unlocked(self, state_obj, **kwargs):
+        # Terraform doesn't currently send the lock ID when a force-unlock is done.
+        # If they fix that, then we should compare lock IDs before unlocking.
+        if self.C.LOCK_STATE_KEYWORD in self.tfstate_shelf:
+            del self.tfstate_shelf[self.C.LOCK_STATE_KEYWORD]
+            return True
+        logging.warning('Failed to release lock for ENV %s, already unlocked!' % self.ENV)
+        return False
+
+    def get_lock_state(self):
+        if self.C.TFSTATE_KEYWORD in self.tfstate_shelf:
+            return self.tfstate_shelf[self.C.TFSTATE_KEYWORD]
+        return ''
+
+    def store_tfstate(self, state_obj, **kwargs):
+        self.tfstate_shelf[self.C.TFSTATE_KEYWORD] = state_obj
+        logging.debug('Saved state file for env %s' % self.ENV)
+
+    def get_tfstate(self):
+        return self.tfstate_shelf[self.C.TFSTATE_KEYWORD]

--- a/config.yaml
+++ b/config.yaml
@@ -8,35 +8,18 @@ USE_AUTHENTICATION_SERVICE: false
 AUTHENTICATION_METHOD: ''
 
 BACKEND_PLUGINS_PATH: 'backends'
-BACKEND_CLASS: 'git_backend.GitBackend'
+BACKEND_CLASS: 'pyshelve_backend.PyShelveBackend'
 POST_PROCESS_CLASSES: []
 
 LOG_LEVEL: 'DEBUG' # INFO, DEBUG, WARNING, ERROR
 
 ##
-##  git_backend.GitBackend configuration
+##  pyshelve_backend.PyShelveBackend configuration
 ##
 
-## --- Optional settings: ---
-GIT_WORKING_PATH: null  # Let the app create one in the temp directory of the OS.
+# The path to where the python shelf objects should be saved.
+PYSHELVE_DATA_PATH: '/Users/alastad/PycharmProjects/PyTerraBackTyl/pyshelve'
 
-## --- REQUIRED settings! ---
-# The SSH repo to use to store tfstate, lock status, and logs.
-GIT_REPOSITORY: 'git@github.com:dev-dull/backend_test.git'  # No HTTP/S yet.
-
-# The branch to clone when creating a new environment with Terraform.
-GIT_DEFAULT_CLONE_BRANCH: 'origin/master'
-
-# The format to use for commit messages. Options are case sensitive.
-# Valid values: ID, Operation, Info, Who, Version, Created, Path
-GIT_COMMIT_MESSAGE_FORMAT: '{Who}, {Operation} - {ID}'
-
-# Maximum number of log messages to keep in the GIT_STATE_CHANGE_LOG_FILENAME file.
-GIT_STATE_CHANGE_LOG_SCROLLBACK: 300
-
-# Name of the log file to commit to record locks/unlocks
-GIT_STATE_CHANGE_LOG_FILENAME: 'state_change.log'
-
-# The format to use for logging messages. Options are case sensitive.
-# Valid values: ID, Operation, Info, Who, Version, Created, Path
-GIT_STATE_CHANGE_LOG_FORMAT: '{Created} - {Operation}: {Who} {ID}'
+# The filename for the tfstate shelf objects -- the environment name will be prepended
+# e.g. for environment TEST, file name will be TEST_terraform_state
+PYSHELVE_DB_FILE_NAME: '_terraform_state'


### PR DESCRIPTION
- Use python shelves as a minimal backend class simple enough to also work as a reasonable example.
- Because pyterrabacktyl is passing objects (dictionary) to the backend class, it only makes sense that we should permit the backend class to pass an object back forward.